### PR TITLE
Improve OzonBank CSV Parsing & Output, Clean Transaction Amounts, and Bump NLog to 5.5.0

### DIFF
--- a/Banks/OzonBank/OzonBank.cs
+++ b/Banks/OzonBank/OzonBank.cs
@@ -51,7 +51,9 @@ public sealed class OzonBank : IBank
             if ( line.StartsWith( "ООО <ОЗОН БАНК>", StringComparison.Ordinal ) || string.IsNullOrWhiteSpace( line ) )
                 continue;
 
-            if ( !DateTime.TryParseExact( line, "dd.MM.yyyy HH:mm:ss", CultureInfo.InvariantCulture, DateTimeStyles.None, out _ ) )
+            var formats = new[] { "dd.MM.yyyy HH:mm:ss", "dd.MM.yyyyHH:mm:ss" };
+            DateTime transDate;
+            if (!DateTime.TryParseExact(line, formats, CultureInfo.InvariantCulture, DateTimeStyles.None, out transDate))
                 continue;
 
             // Проверяем, что следующие строки корректно собирают запись
@@ -60,7 +62,7 @@ public sealed class OzonBank : IBank
             var amount = i + 3 < tablesText.Count ? tablesText[ i + 3 ].Trim() : string.Empty;
 
             // Добавляем запись в CSV
-            csvBuilder.AppendLine( $"\"{line}\",\"{document}\",\"{description}\",\"{amount}\"" );
+            csvBuilder.AppendLine( $"\"{transDate.ToString("dd.MM.yyyy HH:mm:ss")}\",\"{document}\",\"{transDate.ToString("HH:mm:ss") + " " + description}\",\"{amount}\"" );
 
             // Пропускаем уже обработанные строки
             i += 3;

--- a/Banks/OzonBank/TransactionMap.cs
+++ b/Banks/OzonBank/TransactionMap.cs
@@ -9,14 +9,14 @@ internal sealed class TransactionMap : ClassMap< Transaction >
 {
     public TransactionMap()
     {
-        Map( static m => m.Date ).Name( "Дата операции" ).TypeConverterOption.Format( "dd.MM.yyyy HH:mm:ss" );
+        Map( static m => m.Date ).Name( "Дата операции" ).TypeConverterOption.Format("dd.MM.yyyy HH:mm:ss");
         Map( static m => m.Id ).Name( "Документ" );
         Map( static m => m.Memo ).Name( "Назначение платежа" );
         Map( static m => m.Amount ).
             Name( "Сумма операции" ).
             Convert( static args =>
                      {
-                         var value = args.Row.GetField( "Сумма операции" )!.Replace( " ", "" ).Replace( "+", "" );
+                         var value = args.Row.GetField( "Сумма операции" )!.Replace( " ", "" ).Replace( "+", "" ).Replace("₽","");
                          return double.Parse( value, CultureInfo.InvariantCulture ) * -1;
                      } );
 

--- a/Messengers/Telegram/Telegram.csproj
+++ b/Messengers/Telegram/Telegram.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NLog" Version="5.4.0" />
+    <PackageReference Include="NLog" Version="5.5.0" />
     <PackageReference Include="Telegram.Bot" Version="22.5.1" />
   </ItemGroup>
 

--- a/YnabClient/YnabClient.csproj
+++ b/YnabClient/YnabClient.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NLog" Version="5.4.0" />
+    <PackageReference Include="NLog" Version="5.5.0" />
     <PackageReference Include="Stateless" Version="5.17.0" />
     <PackageReference Include="Telegram.Bot" Version="22.5.1" />
     <PackageReference Include="YamlDotNet" Version="16.3.0" />


### PR DESCRIPTION
This pull request introduces several updates to improve functionality and maintainability across different components of the codebase. Key changes include enhancements to date parsing and CSV generation in `OzonBank`, adjustments to transaction mapping logic, and upgrades to the `NLog` package in multiple projects.

### Enhancements to `OzonBank` functionality:

* **Improved date parsing**: Added support for an additional date format (`dd.MM.yyyyHH:mm:ss`) in the `ConvertToCsv` method to ensure compatibility with varying input formats.
* **Enhanced CSV generation**: Modified the CSV output to include a formatted transaction date and time, along with a combined description field for better readability.

### Adjustments to transaction mapping:

* **Transaction amount parsing**: Updated the `TransactionMap` logic to remove the "₽" currency symbol during parsing, ensuring clean numerical values for calculations.

### Dependency upgrades:

* **`NLog` package update**: Upgraded `NLog` from version `5.4.0` to `5.5.0` in both `Telegram` and `YnabClient` projects to leverage improvements and fixes in the newer version. [[1]](diffhunk://#diff-cf91fcd72d46d903e1ecea4a6367cc668b613e54b09ebf5981db191f30bbb60fL14-R14) [[2]](diffhunk://#diff-6bbb99958816c24f6dc1f05163e7680b22098f55b67c9bf4a578610808a825e3L18-R18)