### PR TITLE
Add Kaspi Gold PDF statement parser

### DIFF
--- a/BankTest/Program.cs
+++ b/BankTest/Program.cs
@@ -6,11 +6,11 @@ using Adp.Banks.SberBank;
 
 Encoding.RegisterProvider( CodePagesEncodingProvider.Instance );
 
-var bank = new FreedomBroker();
+var bank = new KaspiPdf();
 //_ = bank.Parse( File.ReadAllText( @"f:\operations Sat Aug 03 07_13_52 MSK 2024-Sun Aug 18 08_33_50 MSK 2024.ofx", Encoding.GetEncoding( bank.FileEncoding ) ) );
 // ReSharper disable once UnusedVariable
 //var trans = bank.Parse( new MemoryStream( File.ReadAllBytes( @"f:\Downloads\Выписка по счёту дебетовой карты.pdf" ) ) );
-const string fileName = @"f:\Downloads\Telegram Desktop\tradernet_table_7A.xlsx";
+const string fileName = @"f:\Downloads\gold_statement (2).pdf";
 bank.IsItYour( fileName );
 var trans = bank.Parse( new MemoryStream( File.ReadAllBytes( fileName ) ) );
 

--- a/Banks/AlfaBank/AlfaBankExcel.cs
+++ b/Banks/AlfaBank/AlfaBankExcel.cs
@@ -9,11 +9,22 @@ namespace Adp.Banks.AlfaBank;
 
 public class AlfaBankExcel : IBank
 {
-    public bool IsItYour( string fileName ) => fileName.Contains( "Statement " ) || fileName.Contains( "statement " );
+    public bool IsItYour( string fileName )
+    {
+        if ( string.IsNullOrWhiteSpace( fileName ) )
+            return false;
+
+        if ( !fileName.EndsWith( ".xlsx", StringComparison.OrdinalIgnoreCase ) )
+            return false;
+
+        var fileNameWithoutExtension = Path.GetFileNameWithoutExtension( fileName );
+        return fileNameWithoutExtension.StartsWith( "Statement ", StringComparison.OrdinalIgnoreCase );
+    }
 
     public List< Transaction > Parse( MemoryStream stream )
     {
         var ret = new List< Transaction >();
+        stream.Position = 0;
 
         ExcelPackage.License.SetNonCommercialPersonal( "Ynab" );
 

--- a/Banks/BCC/Bcc.csproj
+++ b/Banks/BCC/Bcc.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Aspose.PDF" Version="26.1.0" />
+        <PackageReference Include="Aspose.PDF" Version="26.2.0" />
         <PackageReference Include="CsvHelper" Version="33.1.0" />
         <PackageReference Include="EPPlus" Version="8.4.2" />
         <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />

--- a/Banks/BCC/KaspiPdf.cs
+++ b/Banks/BCC/KaspiPdf.cs
@@ -50,8 +50,7 @@ public sealed partial class KaspiPdf : IBank
                 continue;
 
             var operation = NormalizeSpaces( match.Groups[ "operation" ].Value );
-            var details = NormalizeSpaces( match.Groups[ "details" ].Value );
-            var memo = string.IsNullOrWhiteSpace( details ) ? operation : $"{operation} {details}";
+            var memo = NormalizeSpaces( match.Groups[ "details" ].Value );
             var ynabAmount = -1 * signedAmount;
 
             transactions.Add( new Transaction( bankAccount, date, ynabAmount, memo, 0, null, operation ) );

--- a/Banks/BCC/KaspiPdf.cs
+++ b/Banks/BCC/KaspiPdf.cs
@@ -1,0 +1,211 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Adp.Banks.Interfaces;
+using Aspose.Pdf;
+using Aspose.Pdf.Text;
+
+namespace Adp.Banks.BCC;
+
+// ReSharper disable once UnusedType.Global
+public sealed partial class KaspiPdf : IBank
+{
+    public bool IsItYour( string fileName )
+    {
+        if ( string.IsNullOrWhiteSpace( fileName ) )
+            return false;
+
+        return fileName.Contains( "gold_statement", StringComparison.OrdinalIgnoreCase )
+               && fileName.EndsWith( ".pdf", StringComparison.OrdinalIgnoreCase );
+    }
+
+    public string FileEncoding => "utf-8";
+
+    public List< Transaction > Parse( MemoryStream stream )
+    {
+        stream.Position = 0;
+        using var pdfDocument = new Document( stream );
+        var bankAccount = ExtractBankAccountFromCell( pdfDocument );
+        var lines = ExtractLines( pdfDocument );
+        var transactions = new List< Transaction >();
+
+        foreach ( var line in lines )
+        {
+            var match = TransactionLineRegex().Match( line );
+            if ( !match.Success )
+                continue;
+
+            var dateText = NormalizeSpaces( match.Groups[ "date" ].Value );
+            if ( !TryParseDate( dateText, out var date ) )
+                continue;
+
+            var amountText = NormalizeSpaces( match.Groups[ "amount" ].Value );
+            if ( !TryParseSignedAmount( amountText, out var signedAmount ) )
+                continue;
+
+            if ( Math.Abs( signedAmount ) < 0.0001 )
+                continue;
+
+            var operation = NormalizeSpaces( match.Groups[ "operation" ].Value );
+            var details = NormalizeSpaces( match.Groups[ "details" ].Value );
+            var memo = string.IsNullOrWhiteSpace( details ) ? operation : $"{operation} {details}";
+            var ynabAmount = -1 * signedAmount;
+
+            transactions.Add( new Transaction( bankAccount, date, ynabAmount, memo, 0, null, operation ) );
+        }
+
+        return transactions;
+    }
+
+    private static string ExtractBankAccountFromCell( Document pdfDocument )
+    {
+        foreach ( var page in pdfDocument.Pages )
+        {
+            var tableAbsorber = new TableAbsorber();
+            tableAbsorber.Visit( page );
+
+            foreach ( var table in tableAbsorber.TableList )
+            {
+                foreach ( var row in table.RowList )
+                {
+                    var cells = row.CellList.Select( static cell => NormalizeSpaces( GetCellText( cell ) ) )
+                                   .Where( static cell => !string.IsNullOrWhiteSpace( cell ) )
+                                   .ToList();
+                    if ( cells.Count == 0 )
+                        continue;
+
+                    for ( var i = 0; i < cells.Count; i++ )
+                    {
+                        var normalized = NormalizeForComparison( cells[ i ] );
+                        if ( normalized != "номерсчета" && normalized != "номерсчёта" )
+                            continue;
+
+                        if ( i + 1 < cells.Count && TryExtractBankAccount( cells[ i + 1 ], out var accountInNextCell ) )
+                            return accountInNextCell;
+
+                        if ( TryExtractBankAccount( string.Join( " ", cells ), out var accountInRow ) )
+                            return accountInRow;
+                    }
+                }
+            }
+        }
+
+        var textAbsorber = new TextAbsorber();
+        pdfDocument.Pages.Accept( textAbsorber );
+        if ( TryExtractBankAccount( textAbsorber.Text, out var bankAccount ) )
+            return bankAccount;
+
+        throw new Exception( "Не удалось найти номер счета в ячейке 'Номер счета'." );
+    }
+
+    private static List< string > ExtractLines( Document pdfDocument )
+    {
+        var textAbsorber = new TextAbsorber();
+        pdfDocument.Pages.Accept( textAbsorber );
+
+        return textAbsorber.Text.Split( [ "\r\n", "\r", "\n" ], StringSplitOptions.RemoveEmptyEntries )
+                           .Select( NormalizeSpaces )
+                           .Where( static line => !string.IsNullOrWhiteSpace( line ) )
+                           .ToList();
+    }
+
+    private static string GetCellText( AbsorbedCell cell )
+    {
+        if ( cell.TextFragments == null )
+            return string.Empty;
+
+        return cell.TextFragments.Aggregate( "", static ( current, fragment ) =>
+            fragment.Segments.Aggregate( current, static ( value, segment ) => value + segment.Text ) );
+    }
+
+    private static bool TryExtractBankAccount( string input, out string bankAccount )
+    {
+        bankAccount = null;
+        if ( string.IsNullOrWhiteSpace( input ) )
+            return false;
+
+        var match = BankAccountRegex().Match( input.ToUpperInvariant() );
+        if ( !match.Success )
+            return false;
+
+        bankAccount = match.Value;
+        return true;
+    }
+
+    private static bool TryParseDate( string input, out DateTime date )
+    {
+        date = default;
+        var normalized = NormalizeSpaces( input );
+        if ( string.IsNullOrWhiteSpace( normalized ) )
+            return false;
+
+        if ( DateTime.TryParseExact( normalized, "dd.MM.yyyy", CultureInfo.InvariantCulture, DateTimeStyles.None,
+                out date ) )
+            return true;
+
+        var parts = normalized.Split( '.', StringSplitOptions.RemoveEmptyEntries );
+        if ( parts.Length != 3 || parts[ 2 ].Length != 2 )
+            return false;
+
+        if ( !int.TryParse( parts[ 0 ], NumberStyles.None, CultureInfo.InvariantCulture, out var day )
+             || !int.TryParse( parts[ 1 ], NumberStyles.None, CultureInfo.InvariantCulture, out var month )
+             || !int.TryParse( parts[ 2 ], NumberStyles.None, CultureInfo.InvariantCulture, out var year ) )
+            return false;
+
+        try
+        {
+            date = new DateTime( year + 2000, month, day );
+            return true;
+        }
+        catch ( ArgumentOutOfRangeException )
+        {
+            return false;
+        }
+    }
+
+    private static bool TryParseSignedAmount( string input, out double value )
+    {
+        value = default;
+        if ( string.IsNullOrWhiteSpace( input ) )
+            return false;
+
+        var normalized = NormalizeSpaces( input ).Replace( "−", "-" )
+                                                 .Replace( " ", "" )
+                                                 .Replace( "\u00A0", "" )
+                                                 .Replace( "\u202F", "" )
+                                                 .Replace( ",", "." );
+        normalized = AmountCleanerRegex().Replace( normalized, string.Empty );
+
+        return double.TryParse( normalized, NumberStyles.AllowLeadingSign | NumberStyles.AllowDecimalPoint,
+                                CultureInfo.InvariantCulture, out value );
+    }
+
+    private static string NormalizeSpaces( string input )
+    {
+        var value = ( input ?? string.Empty ).Replace( '\u00A0', ' ' )
+                                             .Replace( '\u202F', ' ' )
+                                             .Replace( '\t', ' ' );
+        return MultipleSpaceRegex().Replace( value, " " ).Trim();
+    }
+
+    private static string NormalizeForComparison( string input ) =>
+        ComparisonCleanerRegex().Replace( NormalizeSpaces( input ).ToLowerInvariant(), string.Empty );
+
+    [GeneratedRegex( @"^(?<date>\d{2}\.\d{2}\.(?:\d{2}|\d{4}))\s+(?<amount>[+\-−]\s*\d[\d\s\u00A0\u202F]*,\d{2})\s*₸\s+(?<operation>\S+)(?:\s+(?<details>.*))?$" )]
+    private static partial Regex TransactionLineRegex();
+
+    [GeneratedRegex( @"KZ[0-9A-Z]{10,}", RegexOptions.IgnoreCase )]
+    private static partial Regex BankAccountRegex();
+
+    [GeneratedRegex( @"[^0-9+\-.]" )]
+    private static partial Regex AmountCleanerRegex();
+
+    [GeneratedRegex( @"[^a-zа-яё0-9]" )]
+    private static partial Regex ComparisonCleanerRegex();
+
+    [GeneratedRegex( @"\s+" )]
+    private static partial Regex MultipleSpaceRegex();
+}

--- a/Banks/OzonBank/OzonBank.csproj
+++ b/Banks/OzonBank/OzonBank.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Aspose.PDF" Version="26.1.0" />
+        <PackageReference Include="Aspose.PDF" Version="26.2.0" />
         <PackageReference Include="CsvHelper" Version="33.1.0" />
     </ItemGroup>
 

--- a/Banks/SberBank/SberBank.csproj
+++ b/Banks/SberBank/SberBank.csproj
@@ -7,7 +7,7 @@
 
     <ItemGroup>
         <PackageReference Include="CsvHelper" Version="33.1.0" />
-        <PackageReference Include="Aspose.PDF" Version="26.1.0" />
+        <PackageReference Include="Aspose.PDF" Version="26.2.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/YnabBotService/Dockerfile
+++ b/YnabBotService/Dockerfile
@@ -13,7 +13,6 @@ WORKDIR /src
 COPY ["YnabBotService/YnabBotService.csproj", "YnabBotService/"]
 COPY ["Banks/AlfaBank/AlfaBank.csproj", "Banks/AlfaBank/"]
 COPY ["Banks/Interfaces/Interfaces.csproj", "Banks/Interfaces/"]
-COPY ["Banks/Citibank/Citibank.csproj", "Banks/Citibank/"]
 COPY ["Banks/OzonBank/OzonBank.csproj", "Banks/OzonBank/"]
 COPY ["Banks/SberBank/SberBank.csproj", "Banks/SberBank/"]
 COPY ["Banks/BCC/Bcc.csproj", "Banks/BCC/"]

--- a/YnabBotService/YnabBotService.csproj
+++ b/YnabBotService/YnabBotService.csproj
@@ -19,7 +19,7 @@
 
     <ItemGroup>
         <PackageReference Include="Autofac" Version="9.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.2" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.3" />
         <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
         <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="9.0.0" />
     </ItemGroup>


### PR DESCRIPTION
This pull request introduces support for parsing Kaspi Gold PDF statements, updates several package dependencies, and improves bank file detection logic. The most significant change is the addition of the `KaspiPdf` parser, which enables processing Kaspi Gold account statements in PDF format. Other changes include dependency updates for `Aspose.PDF`, enhancements to AlfaBank Excel file detection, and minor project configuration adjustments.

### Kaspi Gold PDF statement support

* Added new `KaspiPdf` class in `Banks/BCC/KaspiPdf.cs` to parse Kaspi Gold PDF statements, including robust extraction of account numbers and transactions from PDF tables and text.
* Changed test setup in `BankTest/Program.cs` to use `KaspiPdf` and a Kaspi Gold PDF file for parsing.

### Dependency updates

* Updated `Aspose.PDF` package version from `26.1.0` to `26.2.0` in `Banks/BCC/Bcc.csproj`, `Banks/OzonBank/OzonBank.csproj`, and `Banks/SberBank/SberBank.csproj` for improved PDF parsing features and bug fixes. [[1]](diffhunk://#diff-11649d8a7cff2c99b332bd93fc1386cf0aee30bcd988b892ba32733904fab93bL9-R9) [[2]](diffhunk://#diff-e899fa0fde545c12888e54bcc6100e2e06fd8d5cc134c000ad6e7e39dc0037baL10-R10) [[3]](diffhunk://#diff-a46d41b97f26f30163fd783d2624ceb0a5ca75657aff1986c32b7688ff12a708L10-R10)
* Updated `Microsoft.Extensions.Configuration.UserSecrets` package version from `10.0.2` to `10.0.3` in `YnabBotService/YnabBotService.csproj`.

### Bank file detection improvements

* Enhanced `IsItYour` method in `AlfaBankExcel` to more accurately detect valid statement files by checking for `.xlsx` extension and proper filename prefix.

### Project configuration

* Removed Citibank project reference from `YnabBotService/Dockerfile` to streamline build context.